### PR TITLE
🍻 TI-155: Add Connection Name To Rabbitmq

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## Changes Between 2.12.0 and 2.13.0 (unreleased)
+## Changes Between 2.13.0 and 2.14.0
+
+### Update Bunny Connection Properties
+
+Add the propertie connection_name to Bunny connection
+
+## Changes Between 2.12.0 and 2.13.0
 
 ### Minimum Required Ruby Version
 

--- a/lib/sneakers/publisher.rb
+++ b/lib/sneakers/publisher.rb
@@ -43,7 +43,8 @@ module Sneakers
       Bunny.new(@opts[:amqp], :vhost => @opts[:vhost],
                               :heartbeat => @opts[:heartbeat],
                               :properties => @opts.fetch(:properties, {}),
-                              :logger => Sneakers::logger)
+                              :logger => Sneakers::logger,
+                              :connection_name => @opts[:connection_name])
     end
   end
 end

--- a/lib/sneakers/queue.rb
+++ b/lib/sneakers/queue.rb
@@ -81,7 +81,8 @@ class Sneakers::Queue
     Bunny.new(@opts[:amqp], { vhost: @opts[:vhost],
                             heartbeat: @opts[:heartbeat],
                             properties: @opts.fetch(:properties, {}),
-                            logger: Sneakers::logger })
+                            logger: Sneakers::logger,
+                            connection_name: @opts[:connection_name]})
   end
   private :create_bunny_connection
 end

--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "2.13.0"
+  VERSION = "2.14.0"
 end


### PR DESCRIPTION
# 🎯 Motivation and context
<!--- Why is this change required? -->
<!--- What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
:white_check_mark: Currently, for the SRE team and any development staff member, it's difficult to differentiate one RabbitMQ connection from another in the sense that it's not easy to discern which service it belongs to. The purpose of this PR is to add the connection_name in RabbitMQ to distinguish them and to easily identify if any service has lost connection with RabbitMQ.


## 🛠️ Changes
<!--- with a good, clear, and verbose description of your proposed changes. If possible, include supporting resources such as images or links. [**Remember to follow the Pull Request guides**](https://github.com/monokera-tech/it-guidelines#pull-requests) -->
1. The purpose of this PR is to add the necessary RabbitMQ configuration to set up the connection_name.

## 🧪 How could the QA team test this feature?
1. connecion name added in rabbitmq
![Screenshot from 2024-04-20 14-11-14](https://github.com/monokera-tech/rabbitmq/assets/23710544/d17905a1-96b9-4003-9d34-01f3ea2a1115)

## 🎫 Jira ticket
<!--- Link to the Jira ticket related to this PR -->
[![Jira Ticket](https://img.shields.io/badge/Jira-Ticket%20%23TI--155-blue?style=flat-square&logo=jira)](https://monokera.atlassian.net/browse/TI-155)


## 💻 Additional tasks, flags or envs
<!--- Are there any additional tasks required, such as setting up environment variables or running specific tasks or feature flag? -->

~~~bash
N/A
~~~


## 🚦 Checks

- [x] 📦 Create a small and one-feature pull request.
- [ ] 📚 Add and/or update the related documentation.
- [ ] :heart: Ensure you have written good tests
- [x] 👥 Assign yourself and your direct collaborators to the pull request.
- [x] 👀 Request the reviewers, they are gonna help you to improve your code.
- [x] 🏷️ Add the [right labels](https://github.com/monokera-tech/it-guidelines#good-practices).
